### PR TITLE
Refactor: Rename 'user' table to 'profile' in Convex schema

### DIFF
--- a/src/lib/convex/auth.ts
+++ b/src/lib/convex/auth.ts
@@ -36,7 +36,7 @@ export const syncCurrentUser = mutation({
     }
 
     const existingUser = await ctx.db
-      .query("user")
+      .query("profile")
       .withIndex("by_email", (q) => q.eq("email", authUser.email))
       .unique();
 
@@ -62,7 +62,7 @@ export const syncCurrentUser = mutation({
     const username = sanitizedUsername;
 
     const usernameConflict = await ctx.db
-      .query("user")
+      .query("profile")
       .withIndex("by_username", (q) => q.eq("username", username))
       .unique();
 
@@ -70,7 +70,7 @@ export const syncCurrentUser = mutation({
       throw new UsernameAlreadyTakenError(username);
     }
 
-    const newUserId = await ctx.db.insert("user", {
+    const newUserId = await ctx.db.insert("profile", {
       email: authUser.email,
       username: username,
     });
@@ -94,7 +94,7 @@ export const getCurrentUser = query({
     }
 
     const appUser = await ctx.db
-      .query("user")
+      .query("profile")
       .withIndex("by_email", (q) => q.eq("email", authUser.email))
       .unique();
 

--- a/src/lib/convex/battles.ts
+++ b/src/lib/convex/battles.ts
@@ -8,7 +8,7 @@ import type { Id } from "./_generated/dataModel";
  */
 export const createBattle = mutation({
   args: {
-    userId: v.id("user"),
+    userId: v.id("profile"),
     name: v.string(),
     maxPlayers: v.number(),
     doubleSubmissions: v.boolean(),
@@ -76,14 +76,14 @@ export const createBattle = mutation({
 export const getBattle = query({
   args: {
     battleId: v.id("battles"),
-    userId: v.optional(v.id("user")),
+    userId: v.optional(v.id("profile")),
   },
   returns: v.union(
     v.null(),
     v.object({
       _id: v.id("battles"),
       name: v.string(),
-      creatorId: v.id("user"),
+      creatorId: v.id("profile"),
       status: v.union(v.literal("active"), v.literal("completed")),
       visibility: v.union(v.literal("public"), v.literal("private")),
       maxPlayers: v.number(),
@@ -143,7 +143,7 @@ export const getBattle = query({
  * Get battles for a user (owner or player)
  */
 export const getMyBattles = query({
-  args: { userId: v.id("user") },
+  args: { userId: v.id("profile") },
   returns: v.array(
     v.object({
       _id: v.id("battles"),

--- a/src/lib/convex/friend.ts
+++ b/src/lib/convex/friend.ts
@@ -3,8 +3,8 @@ import { v } from "convex/values";
 
 export const sendFriendRequest = mutation({
   args: {
-    requesterId: v.id("user"),
-    recipientId: v.id("user"),
+    requesterId: v.id("profile"),
+    recipientId: v.id("profile"),
   },
   returns: v.id("friendship"),
   handler: async (ctx, args) => {
@@ -62,7 +62,7 @@ export const sendFriendRequest = mutation({
 export const acceptFriendRequest = mutation({
   args: {
     friendshipId: v.id("friendship"),
-    userId: v.id("user"),
+    userId: v.id("profile"),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -92,7 +92,7 @@ export const acceptFriendRequest = mutation({
 export const rejectFriendRequest = mutation({
   args: {
     friendshipId: v.id("friendship"),
-    userId: v.id("user"),
+    userId: v.id("profile"),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -117,8 +117,8 @@ export const rejectFriendRequest = mutation({
 
 export const removeFriend = mutation({
   args: {
-    userId: v.id("user"),
-    friendId: v.id("user"),
+    userId: v.id("profile"),
+    friendId: v.id("profile"),
   },
   returns: v.null(),
   handler: async (ctx, args) => {
@@ -157,11 +157,11 @@ export const removeFriend = mutation({
 
 export const getFriends = query({
   args: {
-    userId: v.id("user"),
+    userId: v.id("profile"),
   },
   returns: v.array(
     v.object({
-      _id: v.id("user"),
+      _id: v.id("profile"),
       _creationTime: v.number(),
       email: v.string(),
       username: v.string(),
@@ -212,7 +212,7 @@ export const getFriends = query({
 
 export const getPendingFriendRequests = query({
   args: {
-    userId: v.id("user"),
+    userId: v.id("profile"),
   },
   returns: v.object({
     incoming: v.array(
@@ -220,7 +220,7 @@ export const getPendingFriendRequests = query({
         friendshipId: v.id("friendship"),
         createdAt: v.number(),
         requester: v.object({
-          _id: v.id("user"),
+          _id: v.id("profile"),
           _creationTime: v.number(),
           email: v.string(),
           username: v.string(),
@@ -232,7 +232,7 @@ export const getPendingFriendRequests = query({
         friendshipId: v.id("friendship"),
         createdAt: v.number(),
         recipient: v.object({
-          _id: v.id("user"),
+          _id: v.id("profile"),
           _creationTime: v.number(),
           email: v.string(),
           username: v.string(),
@@ -283,8 +283,8 @@ export const getPendingFriendRequests = query({
 
 export const checkFriendshipStatus = query({
   args: {
-    userId1: v.id("user"),
-    userId2: v.id("user"),
+    userId1: v.id("profile"),
+    userId2: v.id("profile"),
   },
   returns: v.union(
     v.object({

--- a/src/lib/convex/invitations.ts
+++ b/src/lib/convex/invitations.ts
@@ -7,7 +7,7 @@ import { v } from "convex/values";
  */
 export const sendInvitation = mutation({
   args: {
-    userId: v.id("user"), // inviter
+    userId: v.id("profile"), // inviter
     battleId: v.id("battles"),
     invitedEmail: v.string(),
   },
@@ -31,7 +31,7 @@ export const sendInvitation = mutation({
     }
 
     const invitedUser = await ctx.db
-      .query("user")
+      .query("profile")
       .withIndex("by_email", (q) => q.eq("email", args.invitedEmail))
       .unique();
 
@@ -102,13 +102,13 @@ export const sendInvitation = mutation({
  * List invitations for a user (by userId or by email).
  */
 export const getMyInvitations = query({
-  args: { userId: v.id("user") },
+  args: { userId: v.id("profile") },
   returns: v.array(
     v.object({
       _id: v.id("invitations"),
       battleId: v.id("battles"),
-      inviterId: v.id("user"),
-      invitedUserId: v.optional(v.id("user")),
+      inviterId: v.id("profile"),
+      invitedUserId: v.optional(v.id("profile")),
       invitedEmail: v.optional(v.string()),
       status: v.union(
         v.literal("pending"),
@@ -149,7 +149,7 @@ export const getMyInvitations = query({
  */
 export const respondToInvitation = mutation({
   args: {
-    userId: v.id("user"),
+    userId: v.id("profile"),
     invitationId: v.id("invitations"),
     response: v.union(v.literal("accepted"), v.literal("declined")),
   },

--- a/src/lib/convex/phase_transitions.ts
+++ b/src/lib/convex/phase_transitions.ts
@@ -168,7 +168,7 @@ export const calculateSessionWinner = internalMutation({
       .collect();
 
     const userTotals = new Map<
-      Id<"user">,
+      Id<"profile">,
       { totalStars: number; submissionIds: string[] }
     >();
     for (const sub of submissions) {

--- a/src/lib/convex/players.ts
+++ b/src/lib/convex/players.ts
@@ -10,7 +10,7 @@ export const getBattlePlayers = query({
   returns: v.array(
     v.object({
       _id: v.id("battlePlayers"),
-      userId: v.id("user"),
+      userId: v.id("profile"),
       username: v.string(),
       joinedAt: v.number(),
       totalStarsEarned: v.number(),
@@ -29,7 +29,7 @@ export const getBattlePlayers = query({
 
     const results = [] as Array<{
       _id: Id<"battlePlayers">;
-      userId: Id<"user">;
+      userId: Id<"profile">;
       username: string;
       joinedAt: number;
       totalStarsEarned: number;
@@ -58,7 +58,7 @@ export const getBattlePlayers = query({
  * Join a battle via invite code
  */
 export const joinBattleByCode = mutation({
-  args: { inviteCode: v.string(), userId: v.id("user") },
+  args: { inviteCode: v.string(), userId: v.id("profile") },
   returns: v.object({
     success: v.boolean(),
     battleId: v.optional(v.id("battles")),

--- a/src/lib/convex/schema.ts
+++ b/src/lib/convex/schema.ts
@@ -2,10 +2,10 @@ import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 
 export default defineSchema({
-  // User table - synced from Better Auth
-  // Better Auth manages authentication (passwords, sessions, etc.)
-  // This table only stores app-specific user data
-  user: defineTable({
+  // Profile table - stores app-specific user data
+  // Better Auth manages authentication (passwords, sessions, etc.) in the 'users' table
+  // This table only stores app-specific profile data
+  profile: defineTable({
     email: v.string(),
     username: v.string(), // Display name and handle for mentions
   })
@@ -16,8 +16,8 @@ export default defineSchema({
   // No need for a custom session table
 
   friendship: defineTable({
-    requesterId: v.id("user"),
-    recipientId: v.id("user"),
+    requesterId: v.id("profile"),
+    recipientId: v.id("profile"),
     status: v.union(
       v.literal("pending"),
       v.literal("accepted"),
@@ -34,7 +34,7 @@ export default defineSchema({
   // Battles core schema
   battles: defineTable({
     name: v.string(),
-    creatorId: v.id("user"),
+    creatorId: v.id("profile"),
     status: v.union(v.literal("active"), v.literal("completed")),
     visibility: v.union(v.literal("public"), v.literal("private")),
     maxPlayers: v.number(),
@@ -70,7 +70,7 @@ export default defineSchema({
   // Song submissions per session
   submissions: defineTable({
     sessionId: v.id("vsSessions"),
-    userId: v.id("user"),
+    userId: v.id("profile"),
     spotifyUrl: v.string(),
     submissionOrder: v.number(), // 1 or 2 for double submissions
     submittedAt: v.number(),
@@ -84,7 +84,7 @@ export default defineSchema({
   // Voting stars per session
   stars: defineTable({
     sessionId: v.id("vsSessions"),
-    voterId: v.id("user"),
+    voterId: v.id("profile"),
     submissionId: v.id("submissions"),
     votedAt: v.number(),
   })
@@ -114,7 +114,7 @@ export default defineSchema({
 
   battlePlayers: defineTable({
     battleId: v.id("battles"),
-    userId: v.id("user"),
+    userId: v.id("profile"),
     joinedAt: v.number(),
     totalStarsEarned: v.number(),
     sessionsWon: v.number(),
@@ -125,8 +125,8 @@ export default defineSchema({
 
   invitations: defineTable({
     battleId: v.id("battles"),
-    inviterId: v.id("user"),
-    invitedUserId: v.optional(v.id("user")),
+    inviterId: v.id("profile"),
+    invitedUserId: v.optional(v.id("profile")),
     invitedEmail: v.optional(v.string()),
     status: v.union(
       v.literal("pending"),

--- a/src/lib/convex/sessions.ts
+++ b/src/lib/convex/sessions.ts
@@ -7,7 +7,7 @@ import { v } from "convex/values";
  */
 export const addSession = mutation({
   args: {
-    userId: v.id("user"),
+    userId: v.id("profile"),
     battleId: v.id("battles"),
     vibe: v.string(),
     description: v.optional(v.string()),
@@ -101,7 +101,7 @@ export const addSession = mutation({
  */
 export const updateSession = mutation({
   args: {
-    userId: v.id("user"),
+    userId: v.id("profile"),
     sessionId: v.id("vsSessions"),
     vibe: v.optional(v.string()),
     description: v.optional(v.string()),

--- a/src/lib/convex/spotify.ts
+++ b/src/lib/convex/spotify.ts
@@ -4,7 +4,7 @@ import { internal } from "./_generated/api";
 
 // Public mutation to manually trigger playlist generation (creator-only)
 export const requestGenerateSessionPlaylist = mutation({
-  args: { userId: v.id("user"), sessionId: v.id("vsSessions") },
+  args: { userId: v.id("profile"), sessionId: v.id("vsSessions") },
   returns: v.object({ success: v.boolean(), message: v.string() }),
   handler: async (ctx, args) => {
     const session = await ctx.db.get(args.sessionId);
@@ -37,7 +37,7 @@ export const getSessionForPlaylist = internalQuery({
       sessionNumber: v.number(),
       vibe: v.string(),
       battleName: v.string(),
-      battleCreatorId: v.id("user"),
+      battleCreatorId: v.id("profile"),
       submissions: v.array(
         v.object({
           spotifyUrl: v.string(),

--- a/src/lib/convex/spotify_actions.ts
+++ b/src/lib/convex/spotify_actions.ts
@@ -66,7 +66,7 @@ export const generateSessionPlaylist = internalAction({
 
 // Public action to generate now and return URL immediately
 export const generatePlaylistNow = action({
-  args: { userId: v.id("user"), sessionId: v.id("vsSessions") },
+  args: { userId: v.id("profile"), sessionId: v.id("vsSessions") },
   returns: v.object({
     success: v.boolean(),
     message: v.string(),

--- a/src/lib/convex/submissions.ts
+++ b/src/lib/convex/submissions.ts
@@ -10,7 +10,7 @@ import type { Id } from "./_generated/dataModel";
  */
 export const submitSong = mutation({
   args: {
-    userId: v.id("user"),
+    userId: v.id("profile"),
     sessionId: v.id("vsSessions"),
     spotifyUrl: v.string(),
   },
@@ -138,12 +138,12 @@ export const submitSong = mutation({
 export const getSessionSubmissions = query({
   args: {
     sessionId: v.id("vsSessions"),
-    currentUserId: v.optional(v.id("user")),
+    currentUserId: v.optional(v.id("profile")),
   },
   returns: v.array(
     v.object({
       _id: v.id("submissions"),
-      userId: v.id("user"),
+      userId: v.id("profile"),
       username: v.string(),
       spotifyUrl: v.string(),
       submissionOrder: v.number(),
@@ -186,7 +186,7 @@ export const getSessionSubmissions = query({
  * Get current user's submissions for a session
  */
 export const getMySessionSubmissions = query({
-  args: { sessionId: v.id("vsSessions"), userId: v.id("user") },
+  args: { sessionId: v.id("vsSessions"), userId: v.id("profile") },
   returns: v.array(
     v.object({
       _id: v.id("submissions"),
@@ -220,7 +220,7 @@ export const getMySessionSubmissions = query({
  * Remove a submission (only before deadline)
  */
 export const removeSubmission = mutation({
-  args: { userId: v.id("user"), submissionId: v.id("submissions") },
+  args: { userId: v.id("profile"), submissionId: v.id("submissions") },
   returns: v.object({
     success: v.boolean(),
     message: v.string(),
@@ -277,7 +277,7 @@ export const removeSubmission = mutation({
  */
 export const updateSubmissionUrl = mutation({
   args: {
-    userId: v.id("user"),
+    userId: v.id("profile"),
     submissionId: v.id("submissions"),
     spotifyUrl: v.string(),
   },
@@ -352,7 +352,7 @@ export const getSessionSubmissionStats = query({
     uniqueSubmitters: v.number(),
     submissionsByUser: v.array(
       v.object({
-        userId: v.id("user"),
+        userId: v.id("profile"),
         username: v.string(),
         submissionCount: v.number(),
         submissions: v.array(
@@ -372,9 +372,9 @@ export const getSessionSubmissionStats = query({
       .collect();
 
     const userSubmissions = new Map<
-      Id<"user">,
+      Id<"profile">,
       {
-        user: { _id: Id<"user">; username: string } | null;
+        user: { _id: Id<"profile">; username: string } | null;
         submissions: Array<{
           _id: Id<"submissions">;
           submissionOrder: number;

--- a/src/lib/convex/user.ts
+++ b/src/lib/convex/user.ts
@@ -5,14 +5,14 @@ export const get = query({
   args: {},
   returns: v.array(
     v.object({
-      _id: v.id("user"),
+      _id: v.id("profile"),
       _creationTime: v.number(),
       email: v.string(),
       username: v.string(),
     }),
   ),
   handler: async (ctx) => {
-    return await ctx.db.query("user").collect();
+    return await ctx.db.query("profile").collect();
   },
 });
 
@@ -22,7 +22,7 @@ export const getUserByEmail = query({
   },
   returns: v.union(
     v.object({
-      _id: v.id("user"),
+      _id: v.id("profile"),
       _creationTime: v.number(),
       email: v.string(),
       username: v.string(),
@@ -31,7 +31,7 @@ export const getUserByEmail = query({
   ),
   handler: async (ctx, args) => {
     return await ctx.db
-      .query("user")
+      .query("profile")
       .withIndex("by_email", (q) => q.eq("email", args.email))
       .unique();
   },
@@ -43,7 +43,7 @@ export const getUserByUsername = query({
   },
   returns: v.union(
     v.object({
-      _id: v.id("user"),
+      _id: v.id("profile"),
       _creationTime: v.number(),
       email: v.string(),
       username: v.string(),
@@ -52,22 +52,22 @@ export const getUserByUsername = query({
   ),
   handler: async (ctx, args) => {
     return await ctx.db
-      .query("user")
+      .query("profile")
       .withIndex("by_username", (q) => q.eq("username", args.username))
       .unique();
   },
 });
 
 // Note: User creation is now handled by Better Auth
-// The user table is synced from Better Auth users via syncCurrentUser mutation in auth.ts
+// The profile table is synced from Better Auth users via syncCurrentUser mutation in auth.ts
 
 export const getUserById = query({
   args: {
-    userId: v.id("user"),
+    userId: v.id("profile"),
   },
   returns: v.union(
     v.object({
-      _id: v.id("user"),
+      _id: v.id("profile"),
       _creationTime: v.number(),
       email: v.string(),
       username: v.string(),

--- a/src/lib/convex/voting.ts
+++ b/src/lib/convex/voting.ts
@@ -7,7 +7,7 @@ import { internal } from "./_generated/api";
  */
 export const awardStar = mutation({
   args: {
-    userId: v.id("user"),
+    userId: v.id("profile"),
     submissionId: v.id("submissions"),
   },
   returns: v.object({
@@ -114,7 +114,7 @@ export const awardStar = mutation({
  */
 export const removeStar = mutation({
   args: {
-    userId: v.id("user"),
+    userId: v.id("profile"),
     submissionId: v.id("submissions"),
   },
   returns: v.object({
@@ -195,7 +195,7 @@ export const removeStar = mutation({
  * Get voting state for current user in a session
  */
 export const getMyVotingState = query({
-  args: { sessionId: v.id("vsSessions"), userId: v.id("user") },
+  args: { sessionId: v.id("vsSessions"), userId: v.id("profile") },
   returns: v.object({
     starsRemaining: v.number(),
     votedSubmissions: v.array(v.id("submissions")),
@@ -246,7 +246,7 @@ export const getSessionVotingSummary = query({
     submissionResults: v.array(
       v.object({
         submissionId: v.id("submissions"),
-        userId: v.id("user"),
+        userId: v.id("profile"),
         username: v.string(),
         spotifyUrl: v.string(),
         submissionOrder: v.number(),

--- a/src/routes/battles/+page.server.ts
+++ b/src/routes/battles/+page.server.ts
@@ -30,7 +30,7 @@ export const load: PageServerLoad = async (event) => {
 async function joinBattleByInviteCode(
   client: any,
   inviteCode: string,
-  userId: Id<"user">,
+  userId: Id<"profile">,
 ) {
   const response = await client.mutation(api.players.joinBattleByCode, {
     inviteCode,

--- a/src/routes/battles/[id]/+page.server.ts
+++ b/src/routes/battles/[id]/+page.server.ts
@@ -44,7 +44,7 @@ export const load: PageServerLoad = async (event) => {
  */
 async function sendBattleInvitation(
   client: ConvexHttpClient,
-  userId: Id<"user">,
+  userId: Id<"profile">,
   battleId: Id<"battles">,
   invitedEmail: string,
 ) {

--- a/src/routes/invitations/+page.server.ts
+++ b/src/routes/invitations/+page.server.ts
@@ -44,7 +44,7 @@ export const load: PageServerLoad = async (event) => {
  */
 async function respondToInvitation(
   client: ConvexHttpClient,
-  userId: Id<"user">,
+  userId: Id<"profile">,
   invitationId: Id<"invitations">,
   response: "accepted" | "declined",
 ) {


### PR DESCRIPTION
This change addresses the confusion between the Better Auth 'users' table and the application's custom user table. The application-specific user data table is now named 'profile' to clearly distinguish it from Better Auth's authentication tables.

Changes:
- Renamed 'user' table to 'profile' in schema.ts
- Updated all Convex queries and mutations to reference 'profile' table
- Updated all v.id("user") type references to v.id("profile")
- Updated Id<"user"> type references in route files
- Updated comments to clarify that 'profile' stores app-specific data while Better Auth manages authentication in the 'users' table

Files updated:
- src/lib/convex/schema.ts - table definition
- src/lib/convex/user.ts - profile queries
- src/lib/convex/auth.ts - profile sync
- src/lib/convex/friend.ts - friendship queries
- src/lib/convex/battles.ts - battle queries
- src/lib/convex/players.ts - player queries
- src/lib/convex/submissions.ts - submission queries
- src/lib/convex/invitations.ts - invitation queries
- src/lib/convex/voting.ts - voting queries
- src/lib/convex/sessions.ts - session mutations
- src/lib/convex/phase_transitions.ts - phase logic
- src/lib/convex/spotify.ts - spotify integration
- src/lib/convex/spotify_actions.ts - spotify actions
- src/routes/invitations/+page.server.ts - type refs
- src/routes/battles/+page.server.ts - type refs
- src/routes/battles/[id]/+page.server.ts - type refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)